### PR TITLE
Avoid matching inline tasks

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -266,10 +266,10 @@ export function taskProgressBarExtension(app: App, plugin: TaskProgressBarPlugin
 				// @ts-ignore
 				const tabSize = useTab ? app.vault.getConfig("tabSize") / 4 : app.vault.getConfig("tabSize");
 
-				let bulletCompleteRegex: RegExp = new RegExp(/^[\t|\s]+([-*+]|\d+\.)\s+\[[^ ]\]/);
-				let bulletTotalRegex: RegExp = new RegExp(/^[\t|\s]+([-*+]|\d+\.)\s\[(.)\]/);
-				let headingCompleteRegex: RegExp = new RegExp("([-*+]|\\d+\\.)\\s\\[[^ ]\\]");
-				let headingTotalRegex: RegExp = new RegExp("([-*+]|\\d+\\.)\\s\\[(.)\\]");
+				let bulletCompleteRegex: RegExp = new RegExp(/^\s+([-*+]|\d+\.)\s+\[[^ ]\]/);
+				let bulletTotalRegex: RegExp = new RegExp(/^\s+([-*+]|\d+\.)\s\[(.)\]/);
+				let headingCompleteRegex: RegExp = new RegExp("^\\s*([-*+]|\\d+\\.)\\s\\[[^ ]\\]");
+				let headingTotalRegex: RegExp = new RegExp("^\\s*([-*+]|\\d+\\.)\\s\\[(.)\\]");
 				if (!plugin?.settings.countSubLevel && bullet) {
 					// @ts-ignore
 					level = textArray[0].match(/^[\s|\t]*/)[0].length / tabSize;


### PR DESCRIPTION
Hi Bon - thanks for creating this plugin!

This PR includes a small regex change to avoid capturing inline instances of - [ ] (which don't render as tasks).

Before:
![image](https://github.com/user-attachments/assets/574f1318-3b58-4c16-bde2-be0791e7f752)

After:
![image](https://github.com/user-attachments/assets/8b7add59-cf6b-47be-842b-1a5797b20915)
